### PR TITLE
Fixed the readRegister issue for non-Teensy boards

### DIFF
--- a/src/vn.h
+++ b/src/vn.h
@@ -95,7 +95,7 @@ class VectorNav {
     #if defined(TEENSYDUINO)
     digitalWriteFast(cs_, HIGH);
     #else
-    digitalWrite(cs_, LOW);
+    digitalWrite(cs_, HIGH);
     #endif
     /* Wait for VectorNav to fill response buffer */
     delayMicroseconds(WAIT_TIME_US_);


### PR DESCRIPTION
Fixed the typo in the library that would make the readRegister function return an error for non-Teensy boards.